### PR TITLE
fix spec compliance

### DIFF
--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
@@ -217,16 +217,34 @@ KDSoapMessageAddressingProperties::~KDSoapMessageAddressingProperties()
 
 QString KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::KDSoapAddressingPredefinedAddress address, KDSoapAddressingNamespace addressingNamespace)
 {
-    const QString addressingNS = addressingNamespaceToString(addressingNamespace);
+    QString prefix = addressingNamespaceToString(addressingNamespace);
+    // Up to and including the 2004/08 spec the well-known URIs have a /role/
+    // folder in their path and furthermore only /anonymous is actually
+    // well-known.
+    switch (addressingNamespace) {
+    case Addressing200303:
+    case Addressing200403:
+    case Addressing200408: {
+        prefix += QLatin1String("/role");
+        if (!address == Anonymous) {
+            qWarning("Anything but Anonymous has no meaning in ws-addressing 2004/08");
+            return QString();
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
     switch (address) {
     case Anonymous:
-        return addressingNS + QLatin1String("/anonymous");
+        return prefix + QLatin1String("/anonymous");
     case None:
-        return addressingNS + QLatin1String("/none");
+        return prefix + QLatin1String("/none");
     case Reply:
-        return addressingNS + QLatin1String("/reply");
+        return prefix + QLatin1String("/reply");
     case Unspecified:
-        return addressingNS + QLatin1String("/unspecified");
+        return prefix + QLatin1String("/unspecified");
     default:
         Q_ASSERT(false); // should never happen
         return QString();

--- a/unittests/ws_addressing_support/wsaddressingtest.cpp
+++ b/unittests/ws_addressing_support/wsaddressingtest.cpp
@@ -53,9 +53,12 @@ private Q_SLOTS:
 
         QString unspecified = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Unspecified);
         QCOMPARE(unspecified, QString("http://www.w3.org/2005/08/addressing/unspecified"));
-        
+
         QString none200303 = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::None, KDSoapMessageAddressingProperties::Addressing200303);
-        QCOMPARE(none200303, QString("http://schemas.xmlsoap.org/ws/2003/03/addressing/none"));
+        QCOMPARE(none200303, QString(""));
+
+        QString anon200303 = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Anonymous, KDSoapMessageAddressingProperties::Addressing200303);
+        QCOMPARE(anon200303, QString("http://schemas.xmlsoap.org/ws/2003/03/addressing/role/anonymous"));
     }
 
     void shouldWriteAProperSoapMessageWithRightsAddressingProperties()


### PR DESCRIPTION
as per https://www.w3.org/Submission/ws-addressing/ the only well-known
uri in 2004/08 was anonymous and it has a role prefix. from the
implicit reading I can find on earlier versions the same applies to them.

so, when constructing the well-known URIs inject a role prefix when
dealing with specs up to 2004/08 and raise a warning when attempting to
use anything but anonymous